### PR TITLE
Build on macOS

### DIFF
--- a/QGVCore/GraphViz.pri
+++ b/QGVCore/GraphViz.pri
@@ -15,3 +15,11 @@ win32 {
  INCLUDEPATH += $$GRAPHVIZ_PATH/include/graphviz
  LIBS += -L$$GRAPHVIZ_PATH/lib/release/lib -lgvc -lcgraph -lgraph -lcdt
 }
+macx {
+ # Enable pkg-config (pkg-config is disabled by default in the Qt package for mac)
+ QT_CONFIG -= no-pkg-config
+ # pkg-config location if your brew installation is standard
+ PKG_CONFIG = /usr/local/bin/pkg-config
+ # libgraph is no longer present in last graphviz version
+ PKGCONFIG -= libgraph
+}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Installation :
 * Configure GRAPHVIZ_PATH in QGraphViz.pro
 * Open with Qt Creator & compile
 
+For macOS :
+* Download qgv sources from GIT : git clone https://github.com/nbergont/qgv.git
+* Install Brew packet manager : https://brew.sh
+* Install Graphviz via brew   : $ brew install graphviz
+* Install pkg-config via brew : $ brew install pkg-config
+* Open with Qt Creator & compile
+
 TODO :
 ------
 


### PR DESCRIPTION
Hello,

I would like to share my solution to build qgv on macOS, it would be great if it is integrated in qgv.

Here are my modifications :
* Add macOS instructions in GraphViz.pri in order to build project on macOS : work on macOS 10.13.13 with graphviz-2.40.1.high_sierra.
* Add build instruction for macOS in README.md.